### PR TITLE
misc: Revert email address protection obfuscation

### DIFF
--- a/blog/2018-02-13-getting-ready-gsoc-2018/index.md
+++ b/blog/2018-02-13-getting-ready-gsoc-2018/index.md
@@ -5,7 +5,7 @@ We are happy and excited to announce that we have been accepted by Google as a m
 
 So, what&#8217;s the next step? If you&#8217;re a student and interested in participating in GSoC, head over to our ideas list [0] and see if there&#8217;s a project that you&#8217;re interested in, there&#8217;s a lot of great project ideas! You&#8217;re into Python? Improve our gr_modtool, our out-of-tree creation tool that is used by so many developers! You prefer some number-crunching DSP? Why don&#8217;t you have a look at gr-radar or gr-inspector, a module for blind signal classification? You like making shiny GUIs with Qt? Create a nice app for viewing DTV and show the world what GNU Radio can do!
 
-Once you have found something or even have your own project idea, introduce yourself to the mailing list ([[email&#160;protected]](/cdn-cgi/l/email-protection)), let us know who you are, what you want to do and how you think you are going to achieve that!
+Once you have found something or even have your own project idea, introduce yourself to the mailing list ([discuss-gnuradio](https://lists.gnu.org/mailman/listinfo/discuss-gnuradio)), let us know who you are, what you want to do and how you think you are going to achieve that!
 
 Make sure you also read [1,2] to get an idea how the application process works, what we want to see in a proposal and how to become a successful GSoC student. The general GSoC timeline including the (very important!) deadlines can be found here [3]. The student application period officially begins in 4 weeks (March 12), but do not hesitate to introduce yourself before that date, especially if you have a project idea of your own for which you need to find a mentor!
 

--- a/blog/2018-02-13-gnu-radio-enhancement-proposal-process/index.md
+++ b/blog/2018-02-13-gnu-radio-enhancement-proposal-process/index.md
@@ -7,7 +7,7 @@ The process was announced on [February 5, 2018](https://lists.gnu.org/archive/ht
 
 Subject: [Discuss-gnuradio] Introducing the GREP process
 Date: Mon, 5 Feb 2018 12:42:19 +0100
-From: Martin Braun &lt;[[email&#160;protected]](/cdn-cgi/l/email-protection)&gt;
+From: Martin Braun &lt;martin@gnuradio.org&gt;
 
 Hi all,
 

--- a/events/2017-07-15-sdr-academy-hamradio-friedrichshafen-2017/index.md
+++ b/events/2017-07-15-sdr-academy-hamradio-friedrichshafen-2017/index.md
@@ -32,7 +32,7 @@ Submission Information<br />
 &#8212;&#8212;&#8212;&#8212;&#8212;&#8212;&#8212;&#8212;&#8212;-<br />
 How to submit: Please send an abstract of approximately 250 words to:
 
-[[email&#160;protected]](/cdn-cgi/l/email-protection#ff8c9b8d9ebf9b9e8d9cd19b9a)
+sdra@darc.de
 
 Please include the following information:
 
@@ -84,5 +84,5 @@ Contact<br />
 For enquiries and paper submission details please do not hesitate to<br />
 contact us:
 
-Email: [[email&#160;protected]](/cdn-cgi/l/email-protection#750611071435111407165b1110)<br />
+Email: sdra@darc.de<br />
 Tel.: [+49.89.420956305-0](tel:%2B49.89.420956305-0)

--- a/news/2018-03-05-gsoc-2018/index.md
+++ b/news/2018-03-05-gsoc-2018/index.md
@@ -5,7 +5,7 @@ We are happy and excited to announce that we have been accepted by Google as a m
 
 So, what&#8217;s the next step? If you&#8217;re a student and interested in participating in GSoC, head over to our ideas list [0] and see if there&#8217;s a project that you&#8217;re interested in, there&#8217;s a lot of great project ideas! You&#8217;re into Python? Improve our gr_modtool, our out-of-tree creation tool that is used by so many developers! You prefer some number-crunching DSP? Why don&#8217;t you have a look at gr-radar or gr-inspector, a module for blind signal classification? You like making shiny GUIs with Qt? Create a nice app for viewing DTV and show the world what GNU Radio can do!
 
-Once you have found something or even have your own project idea, introduce yourself to the mailing list ([[email&#160;protected]](/cdn-cgi/l/email-protection)), let us know who you are, what you want to do and how you think you are going to achieve that!
+Once you have found something or even have your own project idea, introduce yourself to the mailing list ([discuss-gnuradio](https://lists.gnu.org/mailman/listinfo/discuss-gnuradio)), let us know who you are, what you want to do and how you think you are going to achieve that!
 
 Make sure you also read [1,2] to get an idea how the application process works, what we want to see in a proposal and how to become a successful GSoC student. The general GSoC timeline including the (very important!) deadlines can be found here [3]. The student application period officially begins in 4 weeks (March 12), but do not hesitate to introduce yourself before that date, especially if you have a project idea of your own for which you need to find a mentor!
 


### PR DESCRIPTION
The conversion to markdown from the saved html meant that email addresses were lost. This restores some but three still need to be fixed.

```
blog/2018-02-21-gnu-radio-challenge-21-feb-2018/index.md
4:At 1222 EST on 21 Feb 2018, we posted a new signals challenge! There are *three* different challenges hidden in this signal capture, and the solution to each is a text message. One is on the easier side, and the two others are more advanced. If you believe you have found a solution, DM the answer to [@gnuradio on Twitter](https://twitter.com/gnuradio) or e-mail [[email&#160;protected]](/cdn-cgi/l/email-protection#791a111815151c171e1c391e170c0b181d101657160b1e)!

events/2016-05-31-meetup-at-wvt-2016/index.md
2:# Meetup at [[email&#160;protected]](/cdn-cgi/l/email-protection) 2016

events/2016-09-16-grcon16-meetup-gsg/index.md
17:Please let us know you are coming so we don&#8217;t run out of provisions! RSVP by September 10th to [[email&#160;protected]](/cdn-cgi/l/email-protection#6e070008012e091c0b0f1a1d0d011a1a090f0a090b1a1d400d0103).
```